### PR TITLE
fix: add type to re-exports

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,5 @@
 import type { JSONContent, Extensions, AnyExtension } from "@tiptap/core";
-export { JSONContent, Extensions };
+export type { JSONContent, Extensions };
 
 export type RenderedNode<T> = T | string | (T | string)[];
 

--- a/vue/types.ts
+++ b/vue/types.ts
@@ -3,6 +3,6 @@ export type * from "../types";
 import type { ComponentSerializers } from "../types";
 
 import type { VNode, Component } from "vue";
-export { Component, VNode };
+export type { Component, VNode };
 
 export type VueComponentSerializers = ComponentSerializers<Component>;


### PR DESCRIPTION
This pull request includes changes to the type exports in the `types.ts` and `vue/types.ts` files. Fixes https://github.com/formfcw/tiptap-render-view/issues/1


* [`types.ts`](diffhunk://#diff-8033e9b81c9757b4f6b0dffdbd5f34f7fbc5a59761f876c863768a9da20ea1b7L2-R2): Changed the export of `JSONContent` and `Extensions` to use `export type` instead of `export`.
* [`vue/types.ts`](diffhunk://#diff-7a5e01049a677fc107c0c18a6d7ca9377914202db1fcdbe425030c1e864d2ed9L6-R6): Changed the export of `Component` and `VNode` to use `export type` instead of `export`.