### PR TITLE
fix: always wrap content in a slot function

### DIFF
--- a/vue/RenderNodes.ts
+++ b/vue/RenderNodes.ts
@@ -37,8 +37,11 @@ export default defineComponent({
             return renderView<VNode>(
                 content,
                 serializers,
-                (tag, attrs, content) => 
-                    h(tag, attrs, { default: () => content})
+                (tag, attrs, content) => {
+                    return typeof tag === 'string' 
+                        ? h(tag, attrs, content as any) 
+                        : h(tag, attrs, { default: () => content});
+                }
             );
         };
     },

--- a/vue/RenderNodes.ts
+++ b/vue/RenderNodes.ts
@@ -37,7 +37,8 @@ export default defineComponent({
             return renderView<VNode>(
                 content,
                 serializers,
-                (tag, attrs, content) => h(tag, attrs, content as any)
+                (tag, attrs, content) => 
+                    h(tag, attrs, { default: () => content})
             );
         };
     },


### PR DESCRIPTION
This PR fixes the `[Vue warn]: Non-function value encountered for default slot. Prefer function slots for better performance.` warning ([discussion](https://github.com/formfcw/tiptap-render-view/discussions/3)).